### PR TITLE
D 04521 swagger rp share wrong

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -72,8 +72,14 @@
 <script src="./sanitizeForMc.js"></script>
 <script>
   window.onload = function() {
+    getBaseUrl = function () {
+      var pathsInUrl = window.location.pathname.split('/');
+      var currentShare = pathsInUrl[0] || pathsInUrl[1];
+      return `${location.protocol}//${location.host}/${currentShare}`;
+    };
+
     const ui = SwaggerUIBundle({
-      url: localStorage.getItem("contextPaths.javaContextPath.REVERSEPROXY") + '/v2/api-docs',
+      url: `${getBaseUrl()}/restapi/v2/api-docs`,
       dom_id: '#swagger-ui',
       deepLinking: true,
       validatorUrl: null,

--- a/dist/index.html
+++ b/dist/index.html
@@ -73,7 +73,7 @@
 <script>
   window.onload = function() {
     getBaseUrl = function () {
-      var pathsInUrl = window.location.pathname.split('/');
+      var pathsInUrl = location.pathname.split('/');
       var currentShare = pathsInUrl[0] || pathsInUrl[1];
       return location.protocol + "//" + location.host + "/" + currentShare;
     };

--- a/dist/index.html
+++ b/dist/index.html
@@ -75,11 +75,11 @@
     getBaseUrl = function () {
       var pathsInUrl = window.location.pathname.split('/');
       var currentShare = pathsInUrl[0] || pathsInUrl[1];
-      return `${location.protocol}//${location.host}/${currentShare}`;
+      return location.protocol + "//" + location.host + "/" + currentShare;
     };
 
     const ui = SwaggerUIBundle({
-      url: `${getBaseUrl()}/restapi/v2/api-docs`,
+      url: getBaseUrl() + "/restapi/v2/api-docs",
       dom_id: '#swagger-ui',
       deepLinking: true,
       validatorUrl: null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
When the reverse proxy path url was changed, swagger stopped working

### Motivation and Context
The fix will grab the url of the current page, get the base path, then point to the desired location for the json documentation (/v2/api-docs).

### How Has This Been Tested?
1. Change reverseproxy path in ems
2. Visit swagger (<rp>/static/swagger/index.html)
3. Swagger page displayed

Repeat steps 2-3 in Chrome, Firefox, and IE.

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x ] are not breaking changes.

### Documentation
- [ x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
- [x ] A manual test is needed
